### PR TITLE
Replace OpenTracing error logs with SignalFx tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ eggs
 lib
 *.egg-info
 build
+.pytest_cache/
 env/
+venv/

--- a/elasticsearch_opentracing/__init__.py
+++ b/elasticsearch_opentracing/__init__.py
@@ -1,3 +1,4 @@
+import traceback
 import threading
 import warnings
 
@@ -95,7 +96,10 @@ class TracingTransport(Transport):
                 rv = super(TracingTransport, self).perform_request(method, url, params, body)
             except Exception as exc:
                 span.set_tag('error', True)
-                span.set_tag('error.object', exc)
+                span.set_tag('sfx.error.object', str(exc.__class__))
+                span.set_tag('sfx.error.kind', exc.__class__.__name__)
+                span.set_tag('sfx.error.message', str(exc))
+                span.set_tag('sfx.error.stack', traceback.format_exc())
                 raise
 
             if isinstance(rv, dict):
@@ -135,7 +139,10 @@ class _TracingTransportWithHeaders(Transport):
                 rv = super(_TracingTransportWithHeaders, self).perform_request(method, url, headers, params, body)
             except Exception as exc:
                 span.set_tag('error', True)
-                span.set_tag('error.object', exc)
+                span.set_tag('sfx.error.object', str(exc.__class__))
+                span.set_tag('sfx.error.kind', exc.__class__.__name__)
+                span.set_tag('sfx.error.message', str(exc))
+                span.set_tag('sfx.error.stack', traceback.format_exc())
                 raise
 
             if isinstance(rv, dict):

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -180,7 +180,9 @@ class TestTracing(unittest.TestCase):
         span = spans[0]
         self.assertEqual(main_span.context.span_id, span.parent_id)
         self.assertEqual(True, span.tags['error'])
-        self.assertEqual(caught_exc, span.tags['error.object'])
+        self.assertEqual(str(caught_exc.__class__), span.tags['sfx.error.object'])
+        self.assertEqual(caught_exc.__class__.__name__, span.tags['sfx.error.kind'])
+        self.assertEqual(str(caught_exc), span.tags['sfx.error.message'])
 
     def test_trace_after_error(self, mock_perform_req):
         init_tracing(self.tracer, trace_all_requests=False)
@@ -202,7 +204,9 @@ class TestTracing(unittest.TestCase):
 
         error_span, span = spans
         self.assertEqual(True, error_span.tags['error'])
-        self.assertEqual(caught_exc, error_span.tags['error.object'])
+        self.assertEqual(str(caught_exc.__class__), error_span.tags['sfx.error.object'])
+        self.assertEqual(caught_exc.__class__.__name__, error_span.tags['sfx.error.kind'])
+        self.assertEqual(str(caught_exc), error_span.tags['sfx.error.message'])
         self.assertNotIn('error', span.tags)
 
     def test_multithreading(self, mock_perform_req):


### PR DESCRIPTION
This PR changes how errors are recorded on spans. It uses the new
SignalFx semantic convention and records the errors as attributes
instead of logs.